### PR TITLE
Update tild.yaml

### DIFF
--- a/vigipool_templates/tild.yaml
+++ b/vigipool_templates/tild.yaml
@@ -43,6 +43,8 @@
         {% else %}
             {{ float(value) * 0.1 }}
         {% endif %}
+    state_class: measurement
+    device_class: temperature
     device:
         configuration_url: https://www.ccei-pool.com/fr/produit/tild-vp
         manufacturer: CCEI


### PR DESCRIPTION
Updates with correct class for Tild temperature; this enables long term statistics https://developers.home-assistant.io/docs/core/entity/sensor/#long-term-statistics

device_class	 = type of sensor
state_class = represents a measurement in present time, not a historical aggregation such as statistics or a prediction of the future. Examples of what should be classified SensorStateClass.MEASUREMENT are: current temperature, humidity or electric power.